### PR TITLE
Fix Entra ID login

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,6 @@ jobs:
           sudo apt update
           sudo apt-get install -y libudev-dev pkg-config
       - name: Generate coverage
-        uses: syyyr/rust-pycobertura-action@v2.0.0
+        uses: syyyr/rust-pycobertura-action@v3.0.0
         with:
           project_name: shvbroker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,9 +2668,10 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shvbroker"
-version = "3.6.4"
+version = "3.6.5"
 dependencies = [
  "assert_cmd",
+ "async-compat",
  "async-tungstenite",
  "cargo-run-bin",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "shvbroker"
-version = "3.6.4"
+version = "3.6.5"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-entra-id = ["dep:graph-rs-sdk"]
+entra-id = ["dep:graph-rs-sdk", "dep:async-compat"]
 
 [dev-dependencies]
 cargo-run-bin = "1.7.4"
@@ -41,6 +41,7 @@ rusqlite = { version = "0.34.0", features = ["bundled"] }
 graph-rs-sdk = { version = "2.0.3", default-features = false, features = ["rustls-tls", ], optional = true }
 serialport = "4.7.1"
 async-tungstenite = "0.29.1"
+async-compat = { version = "0.2.4", optional = true }
 
 # For local development
 #[patch."https://github.com/silicon-heaven/libshvproto-rs"]

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicI64, Ordering};
+
 use async_tungstenite::WebSocketStream;
 use futures::select;
 use futures::FutureExt;
@@ -28,6 +29,8 @@ use crate::serial::create_serial_frame_reader_writer;
 
 #[cfg(feature = "entra-id")]
 use graph_rs_sdk::GraphClient;
+#[cfg(feature = "entra-id")]
+use async_compat::CompatExt;
 
 static G_PEER_COUNT: AtomicI64 = AtomicI64::new(0);
 pub(crate)  fn next_peer_id() -> i64 {
@@ -165,9 +168,11 @@ pub(crate) async fn server_peer_loop(peer_id: PeerId, broker_writer: Sender<Brok
                                 .me()
                                 .get_user()
                                 .send()
+                                .compat()
                                 .await?
                                 .json::<MeResponse>()
                                 .await?;
+
                             user = me_response.mail;
 
                             #[derive(serde::Deserialize)]
@@ -181,12 +186,12 @@ pub(crate) async fn server_peer_loop(peer_id: PeerId, broker_writer: Sender<Brok
                             struct TransitiveMemberOfResponse {
                                 value: Vec<TransitiveMemberOfValue>
                             }
-
                             let groups_response = client
                                 .me()
                                 .transitive_member_of()
                                 .list_transitive_member_of()
                                 .send()
+                                .compat()
                                 .await?
                                 .json::<TransitiveMemberOfResponse>()
                                 .await?;


### PR DESCRIPTION
When moving from async-std to smol, the tokio compatibility layer was removed. This patch re-adds the compatibility layer through async-compat.