### PR TITLE
Add timeouts for login, idle watchdog, and frame I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shvbroker"
-version = "3.7.15"
+version = "3.7.16"
 dependencies = [
  "assert_cmd",
  "async-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvbroker"
-version = "3.7.15"
+version = "3.7.16"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- Introduce `frame_read_timeout` and `frame_write_timeout` helpers with `smol::Timer`
- Add default idle watchdog timeout (180s), overridable via login `options.idleWatchDogTimeOut`
- Enforce 5s timeout for initial login hello/reset, then apply watchdog timeout
- Wrap all frame writer operations with timeout fallback
- Add login timeout (10s) for client peer loop
- Replace direct frame reader loops with timeout-wrapped streams
- Improve debug/error logging for peer session closure and frame send failures
- Bump version to 3.7.16