### PR TITLE
Rework subscriptions management and forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,7 +2599,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shvbroker"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvbroker"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/shvnode.rs
+++ b/src/shvnode.rs
@@ -10,8 +10,7 @@ use shvrpc::rpcframe::RpcFrame;
 use shvrpc::rpcmessage::{PeerId, RpcError, RpcErrorCode};
 use shvrpc::util::strip_prefix_path;
 use crate::brokerimpl::{BrokerToPeerMessage};
-use crate::brokerimpl::{BrokerImpl, NodeRequestContext, SharedBrokerState, state_reader, state_writer};
-use crate::spawn::spawn_and_log_error;
+use crate::brokerimpl::{NodeRequestContext, SharedBrokerState, state_reader, state_writer};
 
 pub const METH_DIR: &str = "dir";
 pub const METH_LS: &str = "ls";
@@ -525,26 +524,14 @@ const BROKER_CURRENT_CLIENT_NODE_METHODS: &[&MetaMethod; 6] = &[
 ];
 impl BrokerCurrentClientNode {
     fn subscribe(peer_id: PeerId, subpar: &SubscriptionParam, state: &SharedBrokerState) -> shvrpc::Result<bool> {
-        log!(target: "Subscr", Level::Debug, "New subscription for peer id: {peer_id} - {subpar:?}");
-        if state_writer(state).subscribe(peer_id, subpar)? {
-            state_writer(state).gc_subscriptions();
-            state_writer(state).update_forwarded_subscriptions()?;
-            spawn_and_log_error(BrokerImpl::renew_forwarded_subscriptions(state.clone()));
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        let res = state_writer(state).subscribe(peer_id, subpar);
+        log!(target: "Subscr", Level::Debug, "subscribe handler for peer id: {peer_id} - {subpar:?}, res: {res:?}");
+        res
     }
     fn unsubscribe(peer_id: PeerId, subpar: &SubscriptionParam, state: &SharedBrokerState) -> shvrpc::Result<bool> {
-        log!(target: "Subscr", Level::Debug, "New subscription for peer id: {peer_id} - {subpar:?}");
-        if state_writer(state).unsubscribe(peer_id, subpar)? {
-            state_writer(state).gc_subscriptions();
-            state_writer(state).update_forwarded_subscriptions()?;
-            spawn_and_log_error(BrokerImpl::renew_forwarded_subscriptions(state.clone()));
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        let res = state_writer(state).unsubscribe(peer_id, subpar);
+        log!(target: "Subscr", Level::Debug, "unsubscribe handler for peer id: {peer_id} - {subpar:?}, res: {res:?}");
+        res
     }
 
 }


### PR DESCRIPTION
(#74, #75)

Implements:
 - Correct propagation to SHV API v2 sub brokers
 - Use reference counting instead of TTL