### PR TITLE
Keep libshv{proto,rpc} compatible with libshvclient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,7 +2515,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shvbroker"
-version = "3.14.4"
+version = "3.14.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2551,8 +2551,8 @@ dependencies = [
 
 [[package]]
 name = "shvclient"
-version = "0.13.2"
-source = "git+https://github.com/silicon-heaven/libshvclient-rs.git?tag=0.13.2#f390ad8955b89b21048b3222acd2124c00ecb46d"
+version = "0.13.3"
+source = "git+https://github.com/silicon-heaven/libshvclient-rs.git?tag=0.13.3#cf3e79077c60b22de69aed28f7de39521ab14373"
 dependencies = [
  "async-broadcast",
  "duration-str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvbroker"
-version = "3.14.4"
+version = "3.14.5"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ entra-id = ["dep:async-compat", "dep:reqwest"]
 [dev-dependencies]
 cargo-run-bin = "1.7.4"
 assert_cmd = "2.0"
-shvclient = { git = "https://github.com/silicon-heaven/libshvclient-rs.git", tag = "0.13.2", features = ["smol"] }
+shvclient = { git = "https://github.com/silicon-heaven/libshvclient-rs.git", tag = "0.13.3", features = ["smol"] }
 tempfile = "3"
 const_format = "0.2.35"
 anyhow = "1.0.100"

--- a/tests/ssl.rs
+++ b/tests/ssl.rs
@@ -49,7 +49,7 @@ async fn start_broker(broker_config: BrokerConfig, broker_address: &str) {
 async fn start_client() -> Option<(ClientCommandSender<()>, ClientEventsReceiver)> {
     let (tx, rx) = futures::channel::oneshot::channel();
     smol::spawn(async {
-        let client_config = ClientConfig {
+        let client_config = shvclient::shvrpc::client::ClientConfig {
             url: Url::parse(PARENT_BROKER_CONNNECT_URL).unwrap(),
             device_id: None,
             mount: None,

--- a/tests/test_broker.rs
+++ b/tests/test_broker.rs
@@ -184,7 +184,7 @@ fn run_testing_device(url: Url, mount_point: &str) {
     const TEXT_MOUNT: &str = "state/text";
     const OVERSIZED_MOUNT: &str = "state/oversized";
 
-    let client_config = ClientConfig {
+    let client_config = shvclient::shvrpc::client::ClientConfig {
         url,
         mount: Some(mount_point.into()),
         ..Default::default()
@@ -200,7 +200,7 @@ fn run_testing_device(url: Url, mount_point: &str) {
             "set" [IsSetter, Write, "Int", "Null"] (param: i32) => {
                 if app_state.number.load(Ordering::SeqCst) != param {
                     app_state.number.store(param, Ordering::SeqCst);
-                    let sigchng = RpcMessage::new_signal(NUMBER_MOUNT, SIG_CHNG, Some(param.into()));
+                    let sigchng = shvclient::shvrpc::RpcMessage::new_signal(NUMBER_MOUNT, SIG_CHNG, Some(param.into()));
                     let _ = client_cmd_tx.send_message(sigchng);
                 }
                 Some(Ok(().into()))
@@ -217,7 +217,7 @@ fn run_testing_device(url: Url, mount_point: &str) {
                 if *app_state.text.read().await != param {
                     let mut writer = app_state.text.write().await;
                     *writer = param.clone();
-                    let sigchng = RpcMessage::new_signal(TEXT_MOUNT, SIG_CHNG, Some(param.into()));
+                    let sigchng = shvclient::shvrpc::RpcMessage::new_signal(TEXT_MOUNT, SIG_CHNG, Some(param.into()));
                     let _ = client_cmd_tx.send_message(sigchng);
                 }
                 Some(Ok(().into()))


### PR DESCRIPTION
Force using data structures from compatible versions of libshv crates.