### PR TITLE
(libshvrpc) Trim trailing zeros only for last CAN FD data frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2515,7 +2515,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shvbroker"
-version = "3.14.8"
+version = "3.14.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2540,7 +2540,7 @@ dependencies = [
  "serialport",
  "shvclient",
  "shvproto",
- "shvrpc",
+ "shvrpc 3.12.1",
  "simple_logger",
  "smol 2.0.2",
  "smol-timeout",
@@ -2564,7 +2564,7 @@ dependencies = [
  "rustls-pemfile",
  "rustls-platform-verifier",
  "shvproto",
- "shvrpc",
+ "shvrpc 3.12.0",
  "smol 2.0.2",
  "url",
 ]
@@ -2586,6 +2586,27 @@ dependencies = [
 name = "shvrpc"
 version = "3.12.0"
 source = "git+https://github.com/silicon-heaven/libshvrpc-rs.git?tag=3.12.0#3eeac8ac6f90746b44482908a214f7ebb5afa264"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "crc",
+ "duration-str",
+ "futures",
+ "futures-time",
+ "glob",
+ "hex",
+ "log",
+ "serde",
+ "serde_yaml",
+ "sha1",
+ "shvproto",
+ "url",
+]
+
+[[package]]
+name = "shvrpc"
+version = "3.12.1"
+source = "git+https://github.com/silicon-heaven/libshvrpc-rs.git?tag=3.12.1#7a8ce41c858daecebc05374737e415fd35371640"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvbroker"
-version = "3.14.8"
+version = "3.14.9"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -27,7 +27,7 @@ panic = "abort"
 
 [dependencies]
 shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs.git", tag = "3.6.2", features = [ "serde" ] }
-shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs.git", tag = "3.12.0", features = ["websocket", "can"] }
+shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs.git", tag = "3.12.1", features = ["websocket", "can"] }
 smol = "2"
 smol-timeout = "0.6"
 futures = "0.3.30"

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -864,15 +864,7 @@ pub(crate) async fn can_interface_task(can_interface_config: CanInterfaceConfig,
                     match maybe_frame {
                         Ok(frame) => {
                             match frame {
-                                socketcan::CanAnyFrame::Normal(_) | socketcan::CanAnyFrame::Fd(_)  => {
-                                    // Handle classic 2.0 frames and FD frames the same way
-                                    let fd_frame: CanFdFrame = match frame.try_into() {
-                                        Ok(fd_frame) => fd_frame,
-                                        Err(err) => {
-                                            error!("Normal or FD frame should be convertible to FD frame: {err}, frame: {frame:?}");
-                                            continue
-                                        }
-                                    };
+                                socketcan::CanAnyFrame::Fd(fd_frame)  => {
                                     let Ok(shvcan_frame) = ShvCanFrame::try_from(&fd_frame) else {
                                         continue
                                     };
@@ -922,6 +914,10 @@ pub(crate) async fn can_interface_task(can_interface_config: CanInterfaceConfig,
                                             reader_ack_tx.clone()
                                         );
                                     }
+                                }
+                                socketcan::CanAnyFrame::Normal(can_normal_frame) => {
+                                    // Ignore non-FD frames
+                                    debug!("CAN 2.0 frame received on {can_iface}: {can_normal_frame:?}");
                                 }
                                 socketcan::CanAnyFrame::Remote(can_remote_frame) => {
                                     // Ignore remote frames


### PR DESCRIPTION
Update libshvrpc to 3.12.1

Ignore received CAN 2.0 frames in peer loop.