### PR TITLE
Parse ShvRI in AccessRule

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,7 +114,7 @@ jobs:
 
   create-releases:
     name: Create releases
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     # FIXME: Enable this needs after Windows build random failures get fixed.
     needs: [build]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,7 +3200,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shvbroker"
-version = "3.31.6"
+version = "3.31.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "shvbroker"
 description = "Rust implementation of the SHV broker"
 license = "MIT"
 repository = "https://github.com/silicon-heaven/shvbroker-rs"
-version = "3.31.6"
+version = "3.31.7"
 edition = "2024"
 default-run = "shvbroker"
 

--- a/src/bin/shvbroker_migrate_legacy.rs
+++ b/src/bin/shvbroker_migrate_legacy.rs
@@ -117,11 +117,7 @@ fn load_roles(conn: &Connection) -> Result<BTreeMap<String, Role>> {
         let grant: String = row.get(3)?;
 
         let shv_ri = format!("{}:{}", if path.is_empty() { "**" } else { &path }, if method.is_empty() { "*" } else { &method });
-        let access_rule = AccessRule { shv_ri, grant };
-
-        if let Err(err) = shvbroker::brokerimpl::ParsedAccessRule::try_from(&access_rule) {
-            panic!("Cannot parse AccessRule from acl_access table, row: {row:?} error: {err}");
-        }
+        let access_rule = AccessRule { shv_ri: shv_ri.try_into().unwrap_or_else(|err| panic!("Cannot parse AccessRule's ShvRI from acl_access table, row: {row:?} error: {err}")), grant };
 
         Ok((role, access_rule))
     })?;

--- a/src/brokerimpl.rs
+++ b/src/brokerimpl.rs
@@ -289,19 +289,6 @@ pub struct ParsedAccessRule {
     pub(crate) access_level: AccessLevel,
 }
 
-impl ParsedAccessRule {
-    pub fn new(shv_ri: &ShvRI, grant: &str) -> shvrpc::Result<Self> {
-        Ok(Self {
-            glob: shv_ri.to_glob()?,
-            access: grant.to_string(),
-            access_level: grant
-                .split(',')
-                .find_map(AccessLevel::from_str)
-                .ok_or_else(|| format!("Invalid access grant `{grant}`"))?,
-        })
-    }
-}
-
 pub(crate) struct PendingRpcCall {
     pub(crate) peer_id: PeerId,
     pub(crate) request_meta: MetaMap,

--- a/src/brokerimpl.rs
+++ b/src/brokerimpl.rs
@@ -1,4 +1,4 @@
-use crate::config::{AccessConfig, AccessRule, ConnectionMountSettings, Listen, Password, Role, SharedBrokerConfig, UpdateSqlOperation, parse_role_access_rules};
+use crate::config::{AccessConfig, ConnectionMountSettings, Listen, Password, Role, SharedBrokerConfig, UpdateSqlOperation, parse_role_access_rules};
 pub use crate::config::{Policy, Policies};
 use crate::shvnode::{
     AppNode, BrokerAccessLastLoginNode, BrokerAccessMountsNode, BrokerAccessPoliciesNode, BrokerAccessRolesNode, BrokerAccessUsersNode, BrokerCurrentClientNode, BrokerNode, DIR_APP, DIR_BROKER, DIR_BROKER_ACCESS_LAST_LOGIN, DIR_BROKER_ACCESS_MOUNTS, DIR_BROKER_ACCESS_POLICIES, DIR_BROKER_ACCESS_ROLES, DIR_BROKER_ACCESS_USERS, DIR_BROKER_CURRENT_CLIENT, DIR_SHV2_BROKER_APP, DIR_SHV2_BROKER_ETC_ACL_MOUNTS, DIR_SHV2_BROKER_ETC_ACL_USERS, METH_LS, METH_SUBSCRIBE, METH_UNSUBSCRIBE, ProcessRequestRetval, SIG_LSMOD, SIG_MNTMOD, Shv2BrokerAppNode, ShvNode, process_local_dir_ls
@@ -288,14 +288,7 @@ pub struct ParsedAccessRule {
     pub(crate) access: String,
     pub(crate) access_level: AccessLevel,
 }
-impl TryFrom<&AccessRule> for ParsedAccessRule {
-    type Error = shvrpc::Error;
 
-    fn try_from(rule: &AccessRule) -> Result<Self, Self::Error> {
-        let ri = ShvRI::try_from(rule.shv_ri.as_str()).map_err(|err| { format!("Parse RI: {} error: {err}", rule.shv_ri) })?;
-        ParsedAccessRule::new(&ri, &rule.grant)
-    }
-}
 impl ParsedAccessRule {
     pub fn new(shv_ri: &ShvRI, grant: &str) -> shvrpc::Result<Self> {
         Ok(Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use log::error;
 use serde::{Serialize, Deserialize};
 use shvproto::RpcValue;
 use shvrpc::client::ClientConfig;
+use shvrpc::metamethod::AccessLevel;
 use shvrpc::rpc::ShvRI;
 use smol::lock::RwLock;
 use url::Url;
@@ -261,6 +262,19 @@ pub struct AccessRule {
     pub grant: String,
 }
 
+impl AccessRule {
+    fn try_parse(&self) -> shvrpc::Result<ParsedAccessRule> {
+        Ok(ParsedAccessRule {
+            glob: self.shv_ri.to_glob()?,
+            access: self.grant.to_string(),
+            access_level: self.grant
+                .split(',')
+                .find_map(AccessLevel::from_str)
+                .ok_or_else(|| format!("Invalid access grant `{}`", self.grant))?,
+        })
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Policy {
     pub allowed_ip: Option<Vec<ipnet::IpNet>>,
@@ -366,7 +380,7 @@ pub(crate) enum UpdateSqlOperation<'a> {
 pub(crate) fn parse_role_access_rules(role: &Role) -> shvrpc::Result<Vec<ParsedAccessRule>> {
     role.access
         .iter()
-        .map(|rule| ParsedAccessRule::new(&rule.shv_ri, &rule.grant))
+        .map(|rule| rule.try_parse())
         .collect::<Result<Vec<_>,_>>()
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use log::error;
 use serde::{Serialize, Deserialize};
 use shvproto::RpcValue;
 use shvrpc::client::ClientConfig;
+use shvrpc::rpc::ShvRI;
 use smol::lock::RwLock;
 use url::Url;
 
@@ -256,7 +257,7 @@ impl TryFrom<&RpcValue> for Role {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct AccessRule {
     #[serde(rename = "shvRI")]
-    pub shv_ri: String,
+    pub shv_ri: ShvRI,
     pub grant: String,
 }
 
@@ -365,7 +366,7 @@ pub(crate) enum UpdateSqlOperation<'a> {
 pub(crate) fn parse_role_access_rules(role: &Role) -> shvrpc::Result<Vec<ParsedAccessRule>> {
     role.access
         .iter()
-        .map(ParsedAccessRule::try_from)
+        .map(|rule| ParsedAccessRule::new(&rule.shv_ri, &rule.grant))
         .collect::<Result<Vec<_>,_>>()
 }
 
@@ -573,14 +574,14 @@ impl Default for BrokerConfig {
                     ("su".to_string(), Role {
                         roles: vec![],
                         access: vec![
-                            AccessRule { shv_ri: "**:*".into(), grant: "su,dot_local".to_string() },
+                            AccessRule { shv_ri: "**:*".try_into().unwrap(), grant: "su,dot_local".to_string() },
                         ],
                         profile: None,
                     }),
                     ("client".to_string(), Role {
                         roles: vec!["ping".to_string(), "subscribe".to_string(), "browse".to_string()],
                         access: vec![
-                            AccessRule { shv_ri: ".broker/currentClient:*".into(), grant: "wr".to_string() },
+                            AccessRule { shv_ri: ".broker/currentClient:*".try_into().unwrap(), grant: "wr".to_string() },
                         ],
                         profile: None,
                     }),
@@ -602,32 +603,32 @@ impl Default for BrokerConfig {
                     ("tester".to_string(), Role {
                         roles: vec!["client".to_string()],
                         access: vec![
-                            AccessRule { shv_ri: ".app/tunnel:create".into(), grant: "wr".to_string() },
-                            AccessRule { shv_ri: ".app/tunnel:ls".into(), grant: "su".to_string() },
-                            AccessRule { shv_ri: ".app/tunnel:dir".into(), grant: "su".to_string() },
-                            AccessRule { shv_ri: "test/**:*".into(), grant: "cfg".to_string() },
+                            AccessRule { shv_ri: ".app/tunnel:create".try_into().unwrap(), grant: "wr".to_string() },
+                            AccessRule { shv_ri: ".app/tunnel:ls".try_into().unwrap(), grant: "su".to_string() },
+                            AccessRule { shv_ri: ".app/tunnel:dir".try_into().unwrap(), grant: "su".to_string() },
+                            AccessRule { shv_ri: "test/**:*".try_into().unwrap(), grant: "cfg".to_string() },
                         ],
                         profile: None,
                     }),
                     ("ping".to_string(), Role {
                         roles: vec![],
                         access: vec![
-                            AccessRule { shv_ri: ".app:ping".into(), grant: "wr".to_string() },
+                            AccessRule { shv_ri: ".app:ping".try_into().unwrap(), grant: "wr".to_string() },
                         ],
                         profile: None,
                     }),
                     ("subscribe".to_string(), Role {
                         roles: vec![],
                         access: vec![
-                            AccessRule { shv_ri: ".broker/currentClient:subscribe".into(), grant: "wr".to_string() },
-                            AccessRule { shv_ri: ".broker/currentClient:unsubscribe".into(), grant: "wr".to_string() },
+                            AccessRule { shv_ri: ".broker/currentClient:subscribe".try_into().unwrap(), grant: "wr".to_string() },
+                            AccessRule { shv_ri: ".broker/currentClient:unsubscribe".try_into().unwrap(), grant: "wr".to_string() },
                         ],
                         profile: None,
                     }),
                     ("browse".to_string(), Role {
                         roles: vec![],
                         access: vec![
-                            AccessRule { shv_ri: "**:*".into(), grant: "bws".to_string() },
+                            AccessRule { shv_ri: "**:*".try_into().unwrap(), grant: "bws".to_string() },
                         ],
                         profile: None,
                     }),

--- a/src/test.rs
+++ b/src/test.rs
@@ -287,7 +287,7 @@ async fn test_broker_loop_as_admin_async() {
                 assert_eq!(&role1, role2);
             }
             {
-                let role = Role { roles: vec!["foo".into()], access: vec![AccessRule{ shv_ri: "bar/**:*".into(), grant: "cfg".into() }], profile: None };
+                let role = Role { roles: vec!["foo".into()], access: vec![AccessRule{ shv_ri: "bar/**:*".try_into().unwrap(), grant: "cfg".into() }], profile: None };
                 call(path, METH_SET_VALUE, Some(vec!["baz".into(), role.to_rpcvalue().unwrap()].into()), &mut call_ctx).await.unwrap();
                 let resp = call(path, METH_LS, None, &mut call_ctx).await.unwrap();
                 let list = resp.as_list();


### PR DESCRIPTION
This adds validation for the shv_ri field for serde. Before, you could create
the AccessRule struct with an invalid ShvRI, and serde would ser/de it without
validation.

ShvRI also had its ser/de changed to serialize as a string, and deser from string with parsing, which makes it compatible with how it was serialized when the shv_ri field was a String.