### PR TITLE
Default allowed_mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3194,7 +3194,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shvbroker"
-version = "3.31.12"
+version = "3.31.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "shvbroker"
 description = "Rust implementation of the SHV broker"
 license = "MIT"
 repository = "https://github.com/silicon-heaven/shvbroker-rs"
-version = "3.31.12"
+version = "3.31.13"
 edition = "2024"
 default-run = "shvbroker"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -295,9 +295,16 @@ impl AccessRule {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Policy {
+    // None values are treated as "allow all"
     pub allowed_ip: Option<Vec<ipnet::IpNet>>,
+
     #[serde(default)]
     pub can_mount_via_device_id: bool,
+
+    // empty vec means "deny all"
+    // ["foo/bar"] allows only mounts under "foo/bar" and all subdirectories
+    // when device is mounted using device-id, than allowed_mounts are ignored
+    #[serde(default)]
     pub allowed_mounts: Vec<String>,
 }
 


### PR DESCRIPTION
Make allowed_mounts serde-default to an empty Vec so a missing field deserializes as deny-all. Document that None for allowed_ip is treated as allow-all.